### PR TITLE
Add AR sessions and ArUco tracking

### DIFF
--- a/Assets/Scenes/TEST1.unity
+++ b/Assets/Scenes/TEST1.unity
@@ -190,10 +190,10 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 971404104}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &971404103
 GameObject:

--- a/Assets/Scripts/ARSetup.cs
+++ b/Assets/Scripts/ARSetup.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+using UnityEngine.XR.ARFoundation;
+using UnityEngine.InputSystem.XR;
+
+public class ARSetup : MonoBehaviour
+{
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    static void Init()
+    {
+        if (FindObjectOfType<ARSession>() == null)
+        {
+            var sessionGO = new GameObject("AR Session");
+            sessionGO.AddComponent<ARSession>();
+        }
+
+        if (FindObjectOfType<ARSessionOrigin>() == null)
+        {
+            var originGO = new GameObject("AR Session Origin");
+            var origin = originGO.AddComponent<ARSessionOrigin>();
+            originGO.AddComponent<ARAnchorManager>();
+
+            var cameraGO = new GameObject("AR Camera");
+            cameraGO.transform.parent = originGO.transform;
+            var cam = cameraGO.AddComponent<Camera>();
+            cameraGO.AddComponent<ARCameraManager>();
+            cameraGO.AddComponent<ArucoTracker>();
+            cameraGO.AddComponent<TrackedPoseDriver>();
+            origin.camera = cam;
+        }
+    }
+}

--- a/Assets/Scripts/ArucoTracker.cs
+++ b/Assets/Scripts/ArucoTracker.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.XR.ARFoundation;
+using UnityEngine.XR.ARSubsystems;
+using Unity.Collections;
+using OpenCvSharp;
+using OpenCvSharp.Aruco;
+
+[RequireComponent(typeof(ARCameraManager))]
+[RequireComponent(typeof(ARSessionOrigin))]
+[RequireComponent(typeof(ARAnchorManager))]
+public class ArucoTracker : MonoBehaviour
+{
+    private ARCameraManager cameraManager;
+    private ARAnchorManager anchorManager;
+    private ARSessionOrigin origin;
+
+    private Dictionary dictionary;
+    private DetectorParameters parameters;
+
+    private readonly Dictionary<int, ARAnchor> anchors = new();
+
+    void Awake()
+    {
+        cameraManager = GetComponent<ARCameraManager>();
+        anchorManager = GetComponent<ARAnchorManager>();
+        origin = GetComponent<ARSessionOrigin>();
+        dictionary = CvAruco.GetPredefinedDictionary(PredefinedDictionaryName.Dict4X4_50);
+        parameters = DetectorParameters.Create();
+    }
+
+    void OnEnable()
+    {
+        cameraManager.frameReceived += OnCameraFrame;
+    }
+
+    void OnDisable()
+    {
+        cameraManager.frameReceived -= OnCameraFrame;
+    }
+
+    void OnCameraFrame(ARCameraFrameEventArgs args)
+    {
+        if (!cameraManager.TryAcquireLatestCpuImage(out XRCpuImage image))
+            return;
+
+        using (image)
+        {
+            var conversionParams = new XRCpuImage.ConversionParams
+            {
+                inputRect = new RectInt(0, 0, image.width, image.height),
+                outputDimensions = new Vector2Int(image.width, image.height),
+                outputFormat = TextureFormat.RGB24,
+                transformation = XRCpuImage.Transformation.MirrorY
+            };
+
+            var size = image.GetConvertedDataSize(conversionParams);
+            using var buffer = new NativeArray<byte>(size, Allocator.Temp);
+            image.Convert(conversionParams, buffer);
+
+            using var mat = new Mat(image.height, image.width, MatType.CV_8UC3, buffer.ToArray());
+            Point2f[][] corners;
+            int[] ids;
+            CvAruco.DetectMarkers(mat, dictionary, out corners, out ids, parameters);
+
+            if (ids != null && ids.Length > 0 && cameraManager.TryGetIntrinsics(out var intr))
+            {
+                var cameraMatrix = new Mat(3, 3, MatType.CV_64FC1);
+                cameraMatrix.Set(0, 0, intr.focalLength.x);
+                cameraMatrix.Set(1, 1, intr.focalLength.y);
+                cameraMatrix.Set(0, 2, intr.principalPoint.x);
+                cameraMatrix.Set(1, 2, intr.principalPoint.y);
+                cameraMatrix.Set(2, 2, 1.0);
+
+                foreach (var anchor in anchors.Values)
+                    anchor.gameObject.SetActive(false);
+
+                for (int i = 0; i < ids.Length; i++)
+                {
+                    Vec3d rvec, tvec;
+                    CvAruco.EstimatePoseSingleMarkers(new[] { corners[i] }, 0.1f, cameraMatrix, new Mat(), out rvec, out tvec);
+                    var pose = new Pose(new Vector3((float)tvec.Item0, (float)tvec.Item1, (float)tvec.Item2),
+                        Quaternion.Euler((float)rvec.Item0, (float)rvec.Item1, (float)rvec.Item2));
+
+                    if (!anchors.TryGetValue(ids[i], out var anchor))
+                    {
+                        anchor = anchorManager.AddAnchor(pose);
+                        if (anchor != null)
+                            anchors.Add(ids[i], anchor);
+                    }
+                    else
+                    {
+                        anchor.transform.SetPositionAndRotation(pose.position, pose.rotation);
+                        anchor.gameObject.SetActive(true);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,4 +1,13 @@
 {
+  "scopedRegistries": [
+    {
+      "name": "OpenUPM",
+      "url": "https://package.openupm.com",
+      "scopes": [
+        "com.unity.cv"
+      ]
+    }
+  ],
   "dependencies": {
     "com.unity.collab-proxy": "2.8.2",
     "com.unity.feature.development": "1.0.1",
@@ -36,6 +45,10 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0"
+    "com.unity.modules.xr": "1.0.0",
+    "com.unity.xr.arfoundation": "6.2.0",
+    "com.unity.xr.arcore": "6.2.0",
+    "com.unity.xr.arkit": "6.2.0",
+    "com.unity.cv.opencv": "1.5.0"
   }
 }

--- a/README.md
+++ b/README.md
@@ -1,33 +1,32 @@
 # QR Engine
 
-Este repositorio contiene un ejemplo sencillo de como detectar y seguir multiples codigos QR en Unity 2022.3.20f1 LTS.
+Este repositorio contiene un ejemplo sencillo de como detectar y seguir marcadores ArUco 4x4 (diccionario 50) en Unity 2022.3.20f1 LTS.
 
-El codigo se basa en la libreria [ZXing.Net](https://github.com/micjahn/ZXing.Net) para la decodificacion de los codigos y utiliza la camara del dispositivo para capturar los frames.
+La deteccion se realiza mediante **OpenCV** y se integra con **AR Foundation** para generar anclas que siguen el marcador en tiempo real. La camara ocupa toda la pantalla y la escena `TEST1` incluye las sesiones AR necesarias.
 
 ## Estructura
 
 ```
 Assets/
   Scripts/
-    MultiQRTracker.cs
+    ArucoTracker.cs
+    ARSetup.cs
 ```
 
-`MultiQRTracker.cs` obtiene la imagen de la camara mediante `WebCamTexture`, decodifica los QR encontrados en cada frame y genera cajas delimitadoras para cada codigo detectado.
+`ArucoTracker.cs` procesa los fotogramas de la camara mediante `ARCameraManager` y usa OpenCV para detectar marcadores ArUco. Cada marcador genera un `ARAnchor` que sigue su pose en tiempo real. `ARSetup.cs` se encarga de crear las sesiones AR necesarias al iniciar la aplicación.
 
 ## Uso
 
-1. Crear un proyecto vacio en Unity (version 2022.3.20f1 o superior).
-2. Importar la libreria **ZXing.Net** (desde NuGet o desde su repositorio como dll para Unity).
-3. Copiar la carpeta `Assets/Scripts` de este repositorio dentro de la carpeta `Assets` de tu proyecto.
-4. Crear un Canvas y un `RawImage` para mostrar la imagen de la camara.
-5. Asignar el prefab que servira como bounding box (puede ser un `Image` con un borde y un componente `Text` para mostrar el contenido del codigo) al campo `boundingBoxPrefab` del componente `MultiQRTracker`.
-6. Ejecutar la escena. La camara se activara y se ajustara automaticamente su orientacion. Se mostraran en pantalla todas las cajas detectadas junto con el texto decodificado.
+1. Crear un proyecto vacío en Unity (versión 2022.3.20f1 o superior).
+2. Copiar la carpeta `Assets/Scripts` de este repositorio dentro de la carpeta `Assets` de tu proyecto.
+3. Abrir la escena `TEST1` y ejecutar. El script `ARSetup` generará un `AR Session` y un `AR Session Origin` con una cámara configurada para realidad aumentada.
+4. `ArucoTracker` detectará marcadores ArUco 4x4 (diccionario 50) y creará anclas que los sigan en tiempo real.
 
 La deteccion se realiza continuamente por lo que los codigos pueden aparecer y desaparecer en pantalla mientras la camara se mantiene activa.
 
 ## Notas
 
-- La libreria ZXing.Net soporta la deteccion de multiples codigos en un mismo frame usando `DecodeMultiple`.
-- Para un rendimiento optimo en dispositivos moviles se recomienda reducir la resolucion de la `WebCamTexture`.
-- El script ajusta cada fotograma la orientacion de la camara para mostrar correctamente la imagen.
+- Este ejemplo usa OpenCV para la deteccion de marcadores ArUco.
+- Se recomienda probar en un dispositivo con soporte ARCore o ARKit para mejores resultados.
+- La camara se ajusta automaticamente para mostrar la imagen en pantalla completa.
 


### PR DESCRIPTION
## Summary
- expand `Packages/manifest.json` with AR Foundation and OpenCV dependencies
- make camera output fill the screen in `TEST1` scene
- implement automatic AR session setup
- add `ArucoTracker` for real-time 4x4_50 marker anchors
- update README to describe the new AR-based approach

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873f150b6fc832a836804c1b88eb1fa